### PR TITLE
Build for ppc64le again

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,10 @@ jobs:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_:
+        CONFIG: linux_ppc64le_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,0 +1,29 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+icu:
+- '75'
+openssl:
+- '3'
+target_platform:
+- linux-ppc64le
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_ppc64le</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21046&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/duckdb-split-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21046&branchName=main">

--- a/recipe/0003-Add-ppc64le-spin-wait-instruction.patch
+++ b/recipe/0003-Add-ppc64le-spin-wait-instruction.patch
@@ -1,0 +1,36 @@
+From 3b32c5ba5142bc98aa7e9598afc7cb7da3a7325a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marvin=20Gie=C3=9Fing?= <marvin.giessing@gmail.com>
+Date: Sat, 7 Jun 2025 11:38:02 +0200
+Subject: [PATCH] Add ppc64le spin-wait instruction
+
+---
+ .../jemalloc/internal/jemalloc_internal_defs.h     | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h b/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+index eab618c829f7..fca216858a29 100644
+--- a/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
++++ b/extension/jemalloc/jemalloc/include/jemalloc/internal/jemalloc_internal_defs.h
+@@ -37,12 +37,18 @@
+  * order to yield to another virtual CPU.
+  */
+ #if defined(__aarch64__) || defined(__ARM_ARCH)
+-#define CPU_SPINWAIT __asm__ volatile("isb")
++    #define CPU_SPINWAIT __asm__ volatile("isb")
++    #define HAVE_CPU_SPINWAIT 1
++#elif defined(__x86_64__) || defined(__i386__)
++    #define CPU_SPINWAIT __asm__ volatile("pause")
++    #define HAVE_CPU_SPINWAIT 1
++#elif defined(__powerpc64__) || defined(__PPC64__)
++    #define CPU_SPINWAIT __asm__ volatile("or 27,27,27")
++    #define HAVE_CPU_SPINWAIT 1
+ #else
+-#define CPU_SPINWAIT __asm__ volatile("pause")
++    #define CPU_SPINWAIT
++    #define HAVE_CPU_SPINWAIT 0
+ #endif
+-/* 1 if CPU_SPINWAIT is defined, 0 otherwise. */
+-#define HAVE_CPU_SPINWAIT 1
+ 
+ /*
+  * Number of significant bits in virtual addresses.  This may be less than the

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
     patches:
       - 0001-Dynamically-link-the-cli.patch
       - 0002-Remove-code-signature-before-applying-metadata-to-ex.patch
+      - 0003-Add-ppc64le-spin-wait-instruction.patch
   - url: https://github.com/duckdb/duckdb-httpfs/archive/af7bcaf40c775016838fef4823666bd18b89b36b.tar.gz
     sha256: e0021f932e714029cdcac3e5ec590e56cd414e2d61ccd7ceb3afecb039ea3024
     folder: extension/httpfs
@@ -20,8 +21,8 @@ source:
     folder: extension/fts
 
 build:
-  number: 0
-  skip: true  # [win or ppc64le]
+  number: 1
+  skip: true  # [win]
 
 requirements:
   build:


### PR DESCRIPTION
Add ppc64le spin-wait instruction patch to recipe and build for ppc64le again

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

@conda-forge-admin, please rerender